### PR TITLE
Replaced forwardRef with ref. Expanded "Phaser Scene Processing" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We have provided a default project structure to get you started. This is as foll
 | `src/App.tsx`                 | The main React component.                                                  |
 | `src/game/EventBus.ts`        | A simple event bus to communicate between React and Phaser.                |
 | `src/game`                    | Contains the game source code.                                             |
-| `src/game/main.tsx`           | The main **game** entry point. This contains the game configuration and starts the game. |
+| `src/game/main.ts`           | The main **game** entry point. This contains the game configuration and starts the game. |
 | `src/game/scenes/`            | The folder where Phaser Scenes are located.                                |
 | `public/style.css`            | Some simple CSS rules to help with page layout.                            |
 | `public/assets`               | Contains the static assets used by the game.                               |
@@ -60,7 +60,7 @@ We have provided a default project structure to get you started. This is as foll
 
 The `PhaserGame.tsx` component is the bridge between React and Phaser. It initializes the Phaser game and passes events between the two.
 
-To communicate between React and Phaser, you can use the **EventBus.js** file. This is a simple event bus that allows you to emit and listen for events from both React and Phaser.
+To communicate between React and Phaser, you can use the **EventBus.ts** file. This is a simple event bus that allows you to emit and listen for events from both React and Phaser.
 
 ```js
 // In React

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We have provided a default project structure to get you started. This is as foll
 | `src/App.tsx`                 | The main React component.                                                  |
 | `src/game/EventBus.ts`        | A simple event bus to communicate between React and Phaser.                |
 | `src/game`                    | Contains the game source code.                                             |
-| `src/game/main.ts`           | The main **game** entry point. This contains the game configuration and starts the game. |
+| `src/game/main.ts`            | The main **game** entry point. This contains the game configuration and starts the game. |
 | `src/game/scenes/`            | The folder where Phaser Scenes are located.                                |
 | `public/style.css`            | Some simple CSS rules to help with page layout.                            |
 | `public/assets`               | Contains the static assets used by the game.                               |

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ EventBus.on('event-name', (data) => {
 });
 ```
 
-In addition to this, the `PhaserGame` component exposes the Phaser game instance along with the most recently active Phaser Scene using React forwardRef.
-
-Once exposed, you can access them like any regular react reference.
+In addition to this, the `PhaserGame` component exposes the Phaser game instance along with the most recently active Phaser Scene using React ref.
 
 ## Phaser Scene Handling
 

--- a/src/PhaserGame.tsx
+++ b/src/PhaserGame.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import StartGame from './game/main';
 import { EventBus } from './game/EventBus';
 
@@ -10,10 +10,11 @@ export interface IRefPhaserGame
 
 interface IProps
 {
-    currentActiveScene?: (scene_instance: Phaser.Scene) => void
+    currentActiveScene?: (scene_instance: Phaser.Scene) => void;
+    ref: React.RefObject<IRefPhaserGame | null>;
 }
 
-export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame({ currentActiveScene }, ref)
+export const PhaserGame = function PhaserGame({ ref, currentActiveScene }: IProps)
 {
     const game = useRef<Phaser.Game | null>(null!);
 
@@ -21,17 +22,12 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
     {
         if (game.current === null)
         {
-
             game.current = StartGame("game-container");
 
-            if (typeof ref === 'function')
-            {
-                ref({ game: game.current, scene: null });
-            } else if (ref)
+            if (ref)
             {
                 ref.current = { game: game.current, scene: null };
             }
-
         }
 
         return () =>
@@ -53,15 +49,10 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
         {
             if (currentActiveScene && typeof currentActiveScene === 'function')
             {
-
                 currentActiveScene(scene_instance);
-
             }
 
-            if (typeof ref === 'function')
-            {
-                ref({ game: game.current, scene: scene_instance });
-            } else if (ref)
+            if (ref)
             {
                 ref.current = { game: game.current, scene: scene_instance };
             }
@@ -76,5 +67,4 @@ export const PhaserGame = forwardRef<IRefPhaserGame, IProps>(function PhaserGame
     return (
         <div id="game-container"></div>
     );
-
-});
+};


### PR DESCRIPTION
1. Fixed typos in README.md.
2. Replaced **forwardRef** with **ref** for React version 19 (https://react.dev/reference/react/forwardRef).
3. The "Phaser Scene Processing" section has been expanded with detailed notes on non-trivial pitfalls. These subtle but important edge cases really confused me and required some time to research, so I believe the added information will be useful to anyone who encounters similar issues.